### PR TITLE
remove print inside __fsubstitute method in fonemas.py

### DIFF
--- a/fonemas/fonemas.py
+++ b/fonemas/fonemas.py
@@ -158,7 +158,6 @@ class Transcription:
 
     @staticmethod
     def __fsubstitute(words):
-        print(words)
         allophones = {'b': 'β', 'd': 'ð', 'g': 'ɣ'}
         for allo in allophones.keys():
             regex = re.compile(r'([^mnɲ\n\-\sˈ][\-\s]{,1}ˈ{,1})' + allo)


### PR DESCRIPTION
Every time is used the class Transcription is printed some text to the console which is a little 
annoying specially when using the library in a cloud service where the logs are important to control.