### PR TITLE
Handling x exceptions

### DIFF
--- a/fonemas/fonemas.py
+++ b/fonemas/fonemas.py
@@ -129,6 +129,14 @@ class Transcription:
             'ph': 'f', 'hie': 'ʝe', 'h': ''
         }
 
+        # Handle 'x' specific cases before replacing 'j'
+        if 'x' in sentence:
+            exceptions_for_x = ['mexico', 'oaxaca', 'texas', 'mexicano', 'mexicana', 'oaxaqueño', 'oaxaqueña', 'texano', 'texano', 'ximena', 'ximenez', 'mexia']
+            for word in sentence.split():
+                if word in exceptions_for_x:
+                    sentence = sentence.replace(word, word.replace('x', 'j'))
+            sentence = re.sub(r'\bx', 's', sentence)
+
         # Apply consonant replacements and handle aspiration
         sentence = re.sub(r'(?:([nls])r|\br|rr)', r'\1R', sentence)
         if aspiration:

--- a/fonemas/fonemas.py
+++ b/fonemas/fonemas.py
@@ -131,7 +131,7 @@ class Transcription:
 
         # Handle 'x' specific cases before replacing 'j'
         if 'x' in sentence:
-            exceptions_for_x = ['mexico', 'oaxaca', 'texas', 'mexicano', 'mexicana', 'oaxaqueño', 'oaxaqueña', 'texano', 'texano', 'ximena', 'ximenez', 'mexia']
+            exceptions_for_x = ['mexico', 'mexicos', 'oaxaca', 'texas', 'mexicano', 'mexicanos', 'mexicana', 'mexicanas', 'oaxaqueño', 'oaxaqueños', 'oaxaqueña', 'oaxaqueñas', 'texano', 'texanos', 'texana', 'texanas', 'ximena', 'ximenez', 'mexia']
             for word in sentence.split():
                 if word in exceptions_for_x:
                     sentence = sentence.replace(word, word.replace('x', 'j'))


### PR DESCRIPTION
The code now handles how x in pronounced in two specific cases: when it starts a word, in which case it becomes /s/, and when found in words with archaic spellings where it becomes /j/, whose word list could be extended if needed.